### PR TITLE
Add compatibility with monolog 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": "^8.0",
     "ext-curl": "*",
-    "monolog/monolog": ">=1.0 <3.0",
+    "monolog/monolog": "^3.0",
     "guzzlehttp/guzzle": "^7.5"
   },
   "autoload": {

--- a/src/Monolog/Formatter/DatadogFormatter.php
+++ b/src/Monolog/Formatter/DatadogFormatter.php
@@ -3,28 +3,16 @@
 namespace sgoettsch\MonologDatadog\Formatter;
 
 use Monolog\Formatter\JsonFormatter;
+use Monolog\Level;
 use Monolog\Logger;
+use Monolog\LogRecord;
 use stdClass;
 
 class DatadogFormatter extends JsonFormatter
 {
-    protected $includeStacktraces = true;
+    protected bool $includeStacktraces = true;
 
-    /**
-     * Map Monolog\Logger levels to Datadog's default status type
-     */
-    private const DATADOG_LEVEL_MAP = [
-        Logger::DEBUG => 'info',
-        Logger::INFO => 'info',
-        Logger::NOTICE => 'warning',
-        Logger::WARNING => 'warning',
-        Logger::ERROR => 'error',
-        Logger::ALERT => 'error',
-        Logger::CRITICAL => 'error',
-        Logger::EMERGENCY => 'error',
-    ];
-
-    public function format(array $record): string
+    public function format(LogRecord $record): string
     {
         $normalized = $this->normalize($record);
 
@@ -36,7 +24,11 @@ class DatadogFormatter extends JsonFormatter
             $normalized['extra'] = new stdClass;
         }
 
-        $normalized['status'] = static::DATADOG_LEVEL_MAP[$record['level']];
+        $normalized['status'] = match ($record['level']) {
+            Level::Debug, Level::Info => 'info',
+            Level::Notice, Level::Warning => 'warning',
+            Level::Error, Level::Alert, Level::Critical, Level::Emergency => 'error',
+        };
 
         return $this->toJson($normalized, true);
     }

--- a/src/Monolog/Handler/DatadogHandler.php
+++ b/src/Monolog/Handler/DatadogHandler.php
@@ -4,9 +4,11 @@ namespace sgoettsch\MonologDatadog\Handler;
 
 use JsonException;
 use Monolog\Handler\MissingExtensionException;
+use Monolog\Level;
 use Monolog\Logger;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Formatter\FormatterInterface;
+use Monolog\LogRecord;
 use sgoettsch\MonologDatadog\Formatter\DatadogFormatter;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
@@ -26,7 +28,7 @@ class DatadogHandler extends AbstractProcessingHandler
      * @param string $apiKey Datadog API-Key
      * @param string $host Datadog API host
      * @param array $attributes Datadog optional attributes
-     * @param int|string $level The minimum logging level at which this handler will be triggered
+     * @param Level $level The minimum logging level at which this handler will be triggered
      * @param bool $bubble Whether the messages that are handled can bubble up the stack or not
      * @throws MissingExtensionException
      */
@@ -34,7 +36,7 @@ class DatadogHandler extends AbstractProcessingHandler
         string $apiKey,
         string $host = 'https://http-intake.logs.datadoghq.com',
         array $attributes = [],
-        int|string $level = Logger::DEBUG,
+        Level $level = Level::Debug,
         bool $bubble = true
     ) {
         if (!extension_loaded('curl')) {
@@ -51,11 +53,11 @@ class DatadogHandler extends AbstractProcessingHandler
     /**
      * Writes the record down to the log of the implementing handler
      *
-     * @param array $record
+     * @param LogRecord $record
      * @return void
      * @throws JsonException
      */
-    protected function write(array $record): void
+    protected function write(LogRecord $record): void
     {
         $this->send($record);
     }
@@ -63,11 +65,11 @@ class DatadogHandler extends AbstractProcessingHandler
     /**
      * Send request to Datadog
      *
-     * @param array $record
+     * @param LogRecord $record
      * @throws JsonException
      * @noinspection SpellCheckingInspection
      */
-    protected function send(array $record): void
+    protected function send(LogRecord $record): void
     {
         $headers = [
             'Content-Type' => 'application/json',
@@ -107,11 +109,11 @@ class DatadogHandler extends AbstractProcessingHandler
     /**
      * Get Datadog Service from $attributes params.
      *
-     * @param array $record
+     * @param LogRecord $record
      *
      * @return string
      */
-    protected function getService(array $record): string
+    protected function getService(LogRecord $record): string
     {
         return $this->attributes['service'] ?? $record['channel'];
     }
@@ -129,11 +131,11 @@ class DatadogHandler extends AbstractProcessingHandler
     /**
      * Get Datadog Tags from $attributes params.
      *
-     * @param array $record
+     * @param LogRecord $record
      *
      * @return string
      */
-    protected function getTags(array $record): string
+    protected function getTags(LogRecord $record): string
     {
         $defaultTag = 'level:' . $record['level_name'];
 


### PR DESCRIPTION
This PR adds compatibility with monolog 3.0.

I would recommend releasing this change as version 3.0.0. By that, all the "old" users that have `"^1.1"` in their composer.json will not be affected. User who want to use the monolog 3 version can do so, by adding `"^3.0"` to their composer.json. We could also use version 2.0.0 for that, but with version 3.0.0 we would show the compatibility with monolog 3 and can orient the versioning on the major and minor version of monolog.

Because the package does not have any tests yet, I was unable to test it by myself. I would test the 3.0 version as soon as it is released in one of our internal projects.