### PR TITLE
Add async Datadog request execution

### DIFF
--- a/src/Monolog/Handler/DatadogHandler.php
+++ b/src/Monolog/Handler/DatadogHandler.php
@@ -6,7 +6,6 @@ use JsonException;
 use Monolog\Formatter\JsonFormatter;
 use Monolog\Handler\MissingExtensionException;
 use Monolog\Level;
-use Monolog\Logger;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\LogRecord;
@@ -24,12 +23,15 @@ class DatadogHandler extends AbstractProcessingHandler
     /** @var array Datadog optional attributes */
     private array $attributes;
 
+    private bool $sendAsync;
+
     /**
      * @param string $apiKey Datadog API-Key
      * @param string $host Datadog API host
      * @param array $attributes Datadog optional attributes
      * @param Level $level The minimum logging level at which this handler will be triggered
      * @param bool $bubble Whether the messages that are handled can bubble up the stack or not
+     * @param bool $sendAsync Whether to send the log asynchronously (requires pcntl extension)
      * @throws MissingExtensionException
      */
     public function __construct(
@@ -37,7 +39,8 @@ class DatadogHandler extends AbstractProcessingHandler
         string $host = 'https://http-intake.logs.datadoghq.com',
         array $attributes = [],
         Level $level = Level::Debug,
-        bool $bubble = true
+        bool $bubble = true,
+        bool $sendAsync = true,
     ) {
         if (!extension_loaded('curl')) {
             throw new MissingExtensionException('The curl extension is needed to use the DatadogHandler');
@@ -48,6 +51,7 @@ class DatadogHandler extends AbstractProcessingHandler
         $this->apiKey = $apiKey;
         $this->host = $host;
         $this->attributes = $attributes;
+        $this->sendAsync = $sendAsync;
     }
 
     /**
@@ -94,11 +98,62 @@ class DatadogHandler extends AbstractProcessingHandler
         $payLoad['hostname'] = $hostname;
         $payLoad['service'] = $service;
 
-        $client = new Client();
         $request = new Request('POST', $url, $headers, json_encode($payLoad, JSON_THROW_ON_ERROR));
 
-        $promise = $client->sendAsync($request);
-        $promise->wait();
+        if ($this->sendAsync()) {
+            $this->sendRequestAsync($request);
+        } else {
+            $this->sendRequestSync($request);
+        }
+    }
+
+    /**
+     * Send request synchronously
+     */
+    private function sendRequestSync(Request $request): void
+    {
+        $client = new Client();
+        $client->send($request);
+    }
+
+    /**
+     * Send request asynchronously
+     */
+    private function sendRequestAsync(Request $request): void
+    {
+        $client = new Client();
+
+        if (!function_exists('pcntl_fork')) {
+            throw new \RuntimeException('pcntl extension is required for async datadog logging');
+        }
+
+        $forkProcess = pcntl_fork();
+
+        if ($forkProcess === -1) {
+            throw new \RuntimeException('Failed to fork process for async datadog logging');
+        }
+
+        if ($forkProcess !== 0) {
+            $promise = $client->sendAsync($request);
+            $promise->wait();
+
+            exit(0);
+        }
+    }
+
+    /**
+     * Check if the log should be sent asynchronously
+     *
+     * @return bool
+     */
+    private function sendAsync(): bool
+    {
+        // Requires pcntl extension and pcntl_fork function
+        if (!function_exists('pcntl_fork')) {
+            return false;
+        }
+
+        return $this->sendAsync;
     }
 
     /**


### PR DESCRIPTION
This PR makes the execution of the request to Datadog asynchronously.

This is achieved by using the `pcntl_fork()` function. That function forks the current PHP process and returns `0` if it is the main process and a process ID if it is the child process.

In the case the process is the child process, we will do the requests and exit the process after that. At that time, the main process keeps running and does not have to wait for the execution of the HTTP request.

The constructor of the `DatadogHandler` received a new parameter `sendAsync` that is `true` by default. It can be set to `false` to disable async handling, f.e. for local development, if needed.