### PR TITLE
Disabling async support

### DIFF
--- a/src/Monolog/Handler/DatadogHandler.php
+++ b/src/Monolog/Handler/DatadogHandler.php
@@ -207,14 +207,12 @@ class DatadogHandler extends AbstractProcessingHandler
 
     private function canAsync(): bool
     {
-        return false;
-        /*
         if (!function_exists('pcntl_fork')) {
             return false;
         }
+        $this->useAsync = false;
 
         return $this->useAsync;
-        */
     }
 
     private function fireAndForget(Client $client, Request $request): bool

--- a/src/Monolog/Handler/DatadogHandler.php
+++ b/src/Monolog/Handler/DatadogHandler.php
@@ -207,11 +207,14 @@ class DatadogHandler extends AbstractProcessingHandler
 
     private function canAsync(): bool
     {
+        return false;
+        /*
         if (!function_exists('pcntl_fork')) {
             return false;
         }
 
         return $this->useAsync;
+        */
     }
 
     private function fireAndForget(Client $client, Request $request): bool


### PR DESCRIPTION
Disabling async support until reworked as current implementation can cause unexpected behavior especially on AWS Lambda